### PR TITLE
Include serde support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "human-repr"
-version = "1.0.1"
+version = "1.1.0"
 edition = "2021"
 authors = ["Rogério Sampaio de Almeida <rsalmei@gmail.com>"]
 description = "Generate beautiful human representations of bytes, durations, and even throughputs!"
@@ -20,7 +20,7 @@ space = []
 serde = { version = "1", optional = true, features = ["derive"] }
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.4"
 serde_json = "1"
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,8 @@
 name = "human-repr"
 version = "1.0.1"
 edition = "2021"
-
 authors = ["Rogério Sampaio de Almeida <rsalmei@gmail.com>"]
-description = "Generate beautiful human representations of bytes, durations and even throughputs!"
+description = "Generate beautiful human representations of bytes, durations, and even throughputs!"
 keywords = ["format", "convert", "bytes", "duration", "throughput"]
 categories = ["value-formatting", "date-and-time"]
 documentation = "https://docs.rs/human-repr/"
@@ -12,15 +11,17 @@ repository = "https://github.com/rsalmei/human-repr"
 readme = "README.md"
 license = "MIT"
 
-[dependencies]
-
 [features]
 1024 = []
 iec = ["1024"]
 space = []
 
+[dependencies]
+serde = { version = "1", optional = true, features = ["derive"] }
+
 [dev-dependencies]
 criterion = "0.3"
+serde_json = "1"
 
 [[bench]]
 name = "counts"

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Then just `use` the needed traits!
 use human_repr::{HumanCount, HumanDuration, HumanThroughput};
 
 3000_u16.human_count("bytes");
--5i8.human_count_bytes();
+(-5i8).human_count_bytes();
 
 4244.32_f32.human_duration();
 0.000000000004432_f64.human_duration();

--- a/benches/counts.rs
+++ b/benches/counts.rs
@@ -2,16 +2,16 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use human_repr::HumanCount;
 use std::fmt::Write;
 
-pub struct Null;
+pub struct Void;
 
-impl Write for Null {
+impl Write for Void {
     fn write_str(&mut self, _s: &str) -> std::fmt::Result {
         Ok(())
     }
 }
 
 fn benchmark<T: HumanCount>(val: T) {
-    let _ = write!(Null, "{}", black_box(val).human_count_bytes());
+    let _ = write!(Void, "{}", black_box(val).human_count_bytes());
 }
 
 pub fn small(c: &mut Criterion) {

--- a/benches/counts.rs
+++ b/benches/counts.rs
@@ -15,7 +15,7 @@ fn benchmark<T: HumanCount>(val: T) {
 }
 
 pub fn small(c: &mut Criterion) {
-    c.bench_function("human-count", |b| b.iter(|| benchmark(1_u32)));
+    c.bench_function("human-count", |b| b.iter(|| benchmark(1_f64)));
 }
 
 criterion_group!(benches, small);

--- a/benches/durations.rs
+++ b/benches/durations.rs
@@ -2,16 +2,16 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use human_repr::HumanDuration;
 use std::fmt::Write;
 
-pub struct Null;
+pub struct Void;
 
-impl Write for Null {
+impl Write for Void {
     fn write_str(&mut self, _s: &str) -> std::fmt::Result {
         Ok(())
     }
 }
 
 fn benchmark<T: HumanDuration>(val: T) {
-    let _ = write!(Null, "{}", black_box(val).human_duration());
+    let _ = write!(Void, "{}", black_box(val).human_duration());
 }
 
 pub fn small(c: &mut Criterion) {

--- a/benches/throughputs.rs
+++ b/benches/throughputs.rs
@@ -2,16 +2,16 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use human_repr::HumanThroughput;
 use std::fmt::Write;
 
-pub struct Null;
+pub struct Void;
 
-impl Write for Null {
+impl Write for Void {
     fn write_str(&mut self, _s: &str) -> std::fmt::Result {
         Ok(())
     }
 }
 
 fn benchmark<T: HumanThroughput>(val: T) {
-    let _ = write!(Null, "{}", black_box(val).human_throughput_bytes());
+    let _ = write!(Void, "{}", black_box(val).human_throughput_bytes());
 }
 
 pub fn small(c: &mut Criterion) {

--- a/src/human_count.rs
+++ b/src/human_count.rs
@@ -106,3 +106,15 @@ mod tests {
         assert_eq!(123000_u64.human_count_bytes(), "123kB");
     }
 }
+
+#[test]
+#[cfg(feature = "serde")]
+fn serialize() -> Result<(), serde_json::Error> {
+    use crate::HumanCount;
+    let h = 123456.human_count("X");
+    let ser = serde_json::to_string(&h)?;
+    assert_eq!(r#"{"val":123456.0,"unit":"X"}"#, &ser);
+    let h2 = serde_json::from_str::<HumanCountData<&str>>(&ser)?;
+    assert_eq!(h, h2);
+    Ok(())
+}

--- a/src/human_count.rs
+++ b/src/human_count.rs
@@ -59,7 +59,7 @@ impl<T: Display> PartialEq<&str> for HumanCountData<T> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(any(feature = "1024", feature = "iec", feature = "space"))))]
 mod tests {
     use crate::HumanCount;
 

--- a/src/human_count.rs
+++ b/src/human_count.rs
@@ -18,7 +18,7 @@ const DIVISOR: f64 = {
     }
 };
 
-impl<T: Display> Display for HumanCountData<T> {
+impl Display for HumanCountData<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let HumanCountData { mut val, unit } = self;
         for (&scale, &dec) in SPEC.iter().zip(DECIMALS) {
@@ -36,7 +36,7 @@ impl<T: Display> Display for HumanCountData<T> {
     }
 }
 
-impl<T: Debug + Display> Debug for HumanCountData<T> {
+impl Debug for HumanCountData<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut ds = f.debug_struct("HumanCount");
         ds.field("val", &self.val);
@@ -47,13 +47,13 @@ impl<T: Debug + Display> Debug for HumanCountData<T> {
     }
 }
 
-impl<T: Display> PartialEq<HumanCountData<T>> for &str {
-    fn eq(&self, other: &HumanCountData<T>) -> bool {
+impl PartialEq<HumanCountData<'_>> for &str {
+    fn eq(&self, other: &HumanCountData<'_>) -> bool {
         utils::display_compare(self, other)
     }
 }
 
-impl<T: Display> PartialEq<&str> for HumanCountData<T> {
+impl PartialEq<&str> for HumanCountData<'_> {
     fn eq(&self, other: &&str) -> bool {
         other == self
     }
@@ -114,7 +114,7 @@ fn serialize() -> Result<(), serde_json::Error> {
     let h = 123456.human_count("X");
     let ser = serde_json::to_string(&h)?;
     assert_eq!(r#"{"val":123456.0,"unit":"X"}"#, &ser);
-    let h2 = serde_json::from_str::<HumanCountData<&str>>(&ser)?;
+    let h2 = serde_json::from_str::<HumanCountData>(&ser)?;
     assert_eq!(h, h2);
     Ok(())
 }

--- a/src/human_count.rs
+++ b/src/human_count.rs
@@ -1,4 +1,5 @@
-use super::{rounded, HumanCountData, SPACE};
+use super::HumanCountData;
+use crate::utils::{self, SPACE};
 use std::fmt::{self, Debug, Display};
 
 // with default features we get: SI symbols, 1000 divisor, and no spaces.
@@ -21,7 +22,7 @@ impl<T: Display> Display for HumanCountData<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let (mut val, unit) = (self.0, &self.1);
         for (&scale, &dec) in SPEC.iter().zip(DECIMALS) {
-            match rounded(val, dec) {
+            match utils::rounded(val, dec) {
                 r if r.abs() >= DIVISOR => val /= DIVISOR,
                 r if r.fract() == 0. => return write!(f, "{:.0}{}{}{}", r, SPACE, scale, unit),
                 r if (r * 10.).fract() == 0. => {
@@ -48,7 +49,7 @@ impl<T: Debug + Display> Debug for HumanCountData<T> {
 
 impl<T: Display> PartialEq<HumanCountData<T>> for &str {
     fn eq(&self, other: &HumanCountData<T>) -> bool {
-        super::display_compare(self, other)
+        utils::display_compare(self, other)
     }
 }
 

--- a/src/human_count.rs
+++ b/src/human_count.rs
@@ -60,14 +60,6 @@ impl<T: AsRef<str>> PartialEq<&str> for HumanCountData<T> {
     }
 }
 
-impl<T> ops::Neg for HumanCountData<T> {
-    type Output = HumanCountData<T>;
-
-    fn neg(self) -> Self::Output {
-        HumanCountData(-self.0, self.1)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use crate::HumanCount;
@@ -79,9 +71,9 @@ mod tests {
         assert_eq!("23B", 23u8.human_count_bytes());
         assert_eq!("23B", 23i8.human_count_bytes());
         assert_eq!("23.5B", 23.5123.human_count_bytes());
-        assert_eq!("-23B", -23i8.human_count_bytes());
+        assert_eq!("-23B", (-23i8).human_count_bytes());
         assert_eq!("1kB", 1025u16.human_count_bytes());
-        assert_eq!("-1kB", -1025i16.human_count_bytes());
+        assert_eq!("-1kB", (-1025i16).human_count_bytes());
         assert_eq!("43.2MB", 43214321u32.human_count_bytes());
         assert_eq!("23.4GB", 23403454432_u64.human_count_bytes());
         assert_eq!("23.43GB", 23433454432_u64.human_count_bytes());

--- a/src/human_count.rs
+++ b/src/human_count.rs
@@ -85,6 +85,7 @@ mod tests {
     fn flexibility() {
         assert_eq!("123MCrabs", 123e6.human_count("Crabs"));
         assert_eq!("123MCrabs", 123e6.human_count("Crabs".to_owned()));
+        assert_eq!("123MCrabs", 123e6.human_count(&"Crabs".to_owned()));
         assert_eq!("123k🦀", 123e3.human_count("🦀"));
         assert_eq!("12.3k°C", 123e2.human_count("°C"));
         assert_eq!("1.2°C", 123e-2.human_count("°C"));

--- a/src/human_count.rs
+++ b/src/human_count.rs
@@ -20,7 +20,7 @@ const DIVISOR: f64 = {
 
 impl<T: Display> Display for HumanCountData<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let (mut val, unit) = (self.0, &self.1);
+        let HumanCountData { mut val, unit } = self;
         for (&scale, &dec) in SPEC.iter().zip(DECIMALS) {
             match utils::rounded(val, dec) {
                 r if r.abs() >= DIVISOR => val /= DIVISOR,
@@ -39,8 +39,8 @@ impl<T: Display> Display for HumanCountData<T> {
 impl<T: Debug + Display> Debug for HumanCountData<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut ds = f.debug_struct("HumanCount");
-        ds.field("val", &self.0);
-        ds.field("unit", &self.1);
+        ds.field("val", &self.val);
+        ds.field("unit", &self.unit);
         ds.finish()?;
         write!(f, " -> ")?;
         fmt::Display::fmt(self, f)

--- a/src/human_count.rs
+++ b/src/human_count.rs
@@ -91,6 +91,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::needless_borrow)]
     fn ownership() {
         let mut a = 42000;
         assert_eq!("42kB", a.human_count_bytes());

--- a/src/human_count.rs
+++ b/src/human_count.rs
@@ -1,5 +1,5 @@
 use super::{rounded, HumanCountData, SPACE};
-use std::{fmt, ops};
+use std::fmt::{self, Debug, Display};
 
 // with default features we get: SI symbols, 1000 divisor, and no spaces.
 const SPEC: &[&str] = {
@@ -17,9 +17,9 @@ const DIVISOR: f64 = {
     }
 };
 
-impl<T: AsRef<str>> fmt::Display for HumanCountData<T> {
+impl<T: Display> Display for HumanCountData<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let (mut val, unit) = (self.0, self.1.as_ref());
+        let (mut val, unit) = (self.0, &self.1);
         for (&scale, &dec) in SPEC.iter().zip(DECIMALS) {
             match rounded(val, dec) {
                 r if r.abs() >= DIVISOR => val /= DIVISOR,
@@ -35,26 +35,24 @@ impl<T: AsRef<str>> fmt::Display for HumanCountData<T> {
     }
 }
 
-impl<T: AsRef<str>> fmt::Debug for HumanCountData<T> {
+impl<T: Debug + Display> Debug for HumanCountData<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut ds = f.debug_struct("HumanCount");
         ds.field("val", &self.0);
-        if !self.1.as_ref().is_empty() {
-            ds.field("unit", &self.1.as_ref());
-        }
+        ds.field("unit", &self.1);
         ds.finish()?;
         write!(f, " -> ")?;
         fmt::Display::fmt(self, f)
     }
 }
 
-impl<T: AsRef<str>> PartialEq<HumanCountData<T>> for &str {
+impl<T: Display> PartialEq<HumanCountData<T>> for &str {
     fn eq(&self, other: &HumanCountData<T>) -> bool {
         super::display_compare(self, other)
     }
 }
 
-impl<T: AsRef<str>> PartialEq<&str> for HumanCountData<T> {
+impl<T: Display> PartialEq<&str> for HumanCountData<T> {
     fn eq(&self, other: &&str) -> bool {
         other == self
     }

--- a/src/human_duration.rs
+++ b/src/human_duration.rs
@@ -53,7 +53,7 @@ impl fmt::Debug for HumanDurationData {
 
 impl PartialEq<HumanDurationData> for &str {
     fn eq(&self, other: &HumanDurationData) -> bool {
-        super::display_compare(*self, other)
+        super::display_compare(self, other)
     }
 }
 
@@ -147,6 +147,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::needless_borrow)]
     fn ownership() {
         let mut a = 0.01;
         assert_eq!("10ms", a.human_duration());

--- a/src/human_duration.rs
+++ b/src/human_duration.rs
@@ -13,7 +13,8 @@ const SPEC: &[(f64, f64, &str, usize)] = &[
 
 impl fmt::Display for HumanDurationData {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut val = self.0 * 1e9;
+        let HumanDurationData { mut val } = self;
+        val *= 1e9;
         for &(size, next, scale, dec) in SPEC {
             match utils::rounded(val, dec) {
                 r if r.abs() >= size => val /= next,
@@ -44,7 +45,7 @@ impl fmt::Display for HumanDurationData {
 impl fmt::Debug for HumanDurationData {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("HumanDuration")
-            .field("val", &self.0)
+            .field("val", &self.val)
             .finish()?;
         write!(f, " -> ")?;
         fmt::Display::fmt(self, f)

--- a/src/human_duration.rs
+++ b/src/human_duration.rs
@@ -166,3 +166,15 @@ mod tests {
         assert_eq!(1.human_duration(), "1s");
     }
 }
+
+#[test]
+#[cfg(feature = "serde")]
+fn serialize() -> Result<(), serde_json::Error> {
+    use HumanDuration;
+    let h = 123456.human_duration();
+    let ser = serde_json::to_string(&h)?;
+    assert_eq!(r#"{"val":123456.0}"#, &ser);
+    let h2 = serde_json::from_str::<HumanDurationData>(&ser)?;
+    assert_eq!(h, h2);
+    Ok(())
+}

--- a/src/human_duration.rs
+++ b/src/human_duration.rs
@@ -131,9 +131,9 @@ mod tests {
         assert_eq!("1s", d!(1.).human_duration());
         assert_eq!("1.5s", d!(1.5).human_duration());
         assert_eq!("1ns", d!(0.00000000123).human_duration());
-        assert_eq!("1ns", d!(0.00000000185).human_duration());
+        assert_eq!("2ns", d!(0.00000000185).human_duration());
         assert_eq!("1ns", d!(0, 1).human_duration());
-        assert_eq!("999ns", d!(0.000000999999999).human_duration());
+        assert_eq!("1µs", d!(0.000000999999999).human_duration());
         assert_eq!("1µs", d!(0, 1000).human_duration());
         assert_eq!("10µs", d!(0, 10000).human_duration());
         assert_eq!("15.6µs", d!(0, 15600).human_duration());

--- a/src/human_duration.rs
+++ b/src/human_duration.rs
@@ -76,7 +76,7 @@ impl HumanDuration for Duration {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(any(feature = "1024", feature = "iec", feature = "space"))))]
 mod tests {
     use crate::HumanDuration;
 

--- a/src/human_duration.rs
+++ b/src/human_duration.rs
@@ -1,6 +1,6 @@
 use super::{rounded, HumanDurationData, SPACE};
+use std::fmt;
 use std::time::Duration;
-use std::{fmt, ops};
 
 const SPEC: &[(f64, f64, &str, usize)] = &[
     (1e3, 1e3, "ns", 1),
@@ -63,14 +63,6 @@ impl PartialEq<&str> for HumanDurationData {
     }
 }
 
-impl ops::Neg for HumanDurationData {
-    type Output = HumanDurationData;
-
-    fn neg(self) -> Self::Output {
-        HumanDurationData(-self.0)
-    }
-}
-
 impl From<Duration> for HumanDurationData {
     fn from(d: Duration) -> Self {
         use crate::HumanDuration;
@@ -85,11 +77,11 @@ mod tests {
     #[test]
     fn operation() {
         assert_eq!("1s", 1.human_duration());
-        assert_eq!("-1s", -1.human_duration());
+        assert_eq!("-1s", (-1).human_duration());
         assert_eq!("1.2ns", 0.00000000123.human_duration());
         assert_eq!("1.8ns", 0.0000000018.human_duration());
         assert_eq!("1µs", 0.000001.human_duration());
-        assert_eq!("-1µs", -0.000001.human_duration());
+        assert_eq!("-1µs", (-0.000001).human_duration());
         assert_eq!("1µs", 0.000000999996.human_duration());
         assert_eq!("10µs", 0.00001.human_duration());
         assert_eq!("15.6µs", 0.0000156.human_duration());

--- a/src/human_throughput.rs
+++ b/src/human_throughput.rs
@@ -1,4 +1,5 @@
-use super::{rounded, HumanThroughputData, SPACE};
+use super::HumanThroughputData;
+use crate::utils::{self, SPACE};
 use std::fmt::{self, Debug, Display};
 
 const SPEC: &[(f64, &str, usize)] = &[
@@ -13,7 +14,7 @@ impl<T: Display> Display for HumanThroughputData<T> {
         let (mut val, unit) = (self.0, &self.1);
         val *= 60. * 60. * 24.;
         for &(size, scale, dec) in SPEC {
-            match rounded(val, dec) {
+            match utils::rounded(val, dec) {
                 r if r.abs() >= size => val /= size,
                 r if r.fract() == 0. => return write!(f, "{:.0}{}{}{}", r, SPACE, unit, scale),
                 r if (r * 10.).fract() == 0. => {
@@ -41,7 +42,7 @@ impl<T: Debug + Display> Debug for HumanThroughputData<T> {
 
 impl<T: Display> PartialEq<HumanThroughputData<T>> for &str {
     fn eq(&self, other: &HumanThroughputData<T>) -> bool {
-        super::display_compare(self, other)
+        utils::display_compare(self, other)
     }
 }
 

--- a/src/human_throughput.rs
+++ b/src/human_throughput.rs
@@ -5,7 +5,7 @@ use std::fmt::{self, Debug, Display};
 const SPEC: &[(f64, &str, usize)] = &[
     (24., "/d", 2),
     (60., "/h", 1),
-    (60., "/m", 1),
+    (60., "/min", 1),
     // "/s" in code.
 ];
 
@@ -62,16 +62,16 @@ mod tests {
         assert_eq!("-1B/s", (-1).human_throughput_bytes());
         assert_eq!("1.2MB/s", (1234567. / 1.).human_throughput_bytes());
         assert_eq!("10B/s", (10. / 1.).human_throughput_bytes());
-        assert_eq!("30B/m", (1. / 2.).human_throughput_bytes());
-        assert_eq!("-30B/m", (-1. / 2.).human_throughput_bytes());
+        assert_eq!("30B/min", (1. / 2.).human_throughput_bytes());
+        assert_eq!("-30B/min", (-1. / 2.).human_throughput_bytes());
         assert_eq!("5B/s", (10. / 2.).human_throughput_bytes());
         assert_eq!("5.5B/s", (11. / 2.).human_throughput_bytes());
-        assert_eq!("6.1B/m", (10. / 99.).human_throughput_bytes());
-        assert_eq!("1.8B/m", (3. / 100.).human_throughput_bytes());
-        assert_eq!("4.4B/m", (8. / 110.).human_throughput_bytes());
+        assert_eq!("6.1B/min", (10. / 99.).human_throughput_bytes());
+        assert_eq!("1.8B/min", (3. / 100.).human_throughput_bytes());
+        assert_eq!("4.4B/min", (8. / 110.).human_throughput_bytes());
         assert_eq!("6.8B/h", (3. / 1600.).human_throughput_bytes());
         assert_eq!("1.9kB/s", (3000000. / 1600.).human_throughput_bytes());
-        assert_eq!("4.8B/m", (54327375. / 675876554.).human_throughput_bytes());
+        assert_eq!("4.8B/min", (5432737. / 67587655.).human_throughput_bytes());
         assert_eq!("28.9B/h", (5432737. / 675876554.).human_throughput_bytes());
         assert_eq!("8B/s", (5432737542. / 675876554.).human_throughput_bytes());
         assert_eq!("1B/s", (1. / 0.99).human_throughput_bytes());

--- a/src/human_throughput.rs
+++ b/src/human_throughput.rs
@@ -91,6 +91,7 @@ mod tests {
     fn flexibility() {
         assert_eq!("123MCrabs/s", 123e6.human_throughput("Crabs"));
         assert_eq!("123MCrabs/s", 123e6.human_throughput("Crabs".to_owned()));
+        assert_eq!("123MCrabs/s", 123e6.human_throughput(&"Crabs".to_owned()));
         assert_eq!("123M🦀/s", 123e6.human_throughput("🦀"));
         assert_eq!("12.3k°C/s", 123e2.human_throughput("°C"));
         assert_eq!("1.2°C/s", 123e-2.human_throughput("°C"));

--- a/src/human_throughput.rs
+++ b/src/human_throughput.rs
@@ -11,7 +11,7 @@ const SPEC: &[(f64, &str, usize)] = &[
 
 impl<T: Display> Display for HumanThroughputData<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let (mut val, unit) = (self.0, &self.1);
+        let HumanThroughputData { mut val, unit } = self;
         val *= 60. * 60. * 24.;
         for &(size, scale, dec) in SPEC {
             match utils::rounded(val, dec) {
@@ -32,8 +32,8 @@ impl<T: Display> Display for HumanThroughputData<T> {
 impl<T: Debug + Display> Debug for HumanThroughputData<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut ds = f.debug_struct("HumanThroughput");
-        ds.field("val", &self.0);
-        ds.field("unit", &self.1);
+        ds.field("val", &self.val);
+        ds.field("unit", &self.unit);
         ds.finish()?;
         write!(f, " -> ")?;
         fmt::Display::fmt(self, f)

--- a/src/human_throughput.rs
+++ b/src/human_throughput.rs
@@ -53,14 +53,6 @@ impl<T: AsRef<str>> PartialEq<&str> for HumanThroughputData<T> {
     }
 }
 
-impl<T> ops::Neg for HumanThroughputData<T> {
-    type Output = HumanThroughputData<T>;
-
-    fn neg(self) -> Self::Output {
-        HumanThroughputData(-self.0, self.1)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use crate::HumanThroughput;
@@ -68,7 +60,7 @@ mod tests {
     #[test]
     fn operation() {
         assert_eq!("1B/s", 1.human_throughput_bytes());
-        assert_eq!("-1B/s", -1.human_throughput_bytes());
+        assert_eq!("-1B/s", (-1).human_throughput_bytes());
         assert_eq!("1.2MB/s", (1234567. / 1.).human_throughput_bytes());
         assert_eq!("10B/s", (10. / 1.).human_throughput_bytes());
         assert_eq!("30B/m", (1. / 2.).human_throughput_bytes());

--- a/src/human_throughput.rs
+++ b/src/human_throughput.rs
@@ -52,7 +52,7 @@ impl<T: Display> PartialEq<&str> for HumanThroughputData<T> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(any(feature = "1024", feature = "iec", feature = "space"))))]
 mod tests {
     use crate::HumanThroughput;
 

--- a/src/human_throughput.rs
+++ b/src/human_throughput.rs
@@ -112,3 +112,15 @@ mod tests {
         assert_eq!(1.human_throughput_bytes(), "1B/s");
     }
 }
+
+#[test]
+#[cfg(feature = "serde")]
+fn serialize() -> Result<(), serde_json::Error> {
+    use crate::HumanThroughput;
+    let h = 123456.human_throughput("X");
+    let ser = serde_json::to_string(&h)?;
+    assert_eq!(r#"{"val":123456.0,"unit":"X"}"#, &ser);
+    let h2 = serde_json::from_str::<HumanThroughputData<&str>>(&ser)?;
+    assert_eq!(h, h2);
+    Ok(())
+}

--- a/src/human_throughput.rs
+++ b/src/human_throughput.rs
@@ -97,6 +97,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::needless_borrow)]
     fn ownership() {
         let mut a = 42000;
         assert_eq!("42kB/s", a.human_throughput_bytes());

--- a/src/human_throughput.rs
+++ b/src/human_throughput.rs
@@ -9,7 +9,7 @@ const SPEC: &[(f64, &str, usize)] = &[
     // "/s" in code.
 ];
 
-impl<T: Display> Display for HumanThroughputData<T> {
+impl Display for HumanThroughputData<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let HumanThroughputData { mut val, unit } = self;
         val *= 60. * 60. * 24.;
@@ -25,11 +25,11 @@ impl<T: Display> Display for HumanThroughputData<T> {
         }
 
         use super::HumanCount;
-        write!(f, "{}/s", val.human_count(unit))
+        write!(f, "{}/s", val.human_count(unit.as_ref()))
     }
 }
 
-impl<T: Debug + Display> Debug for HumanThroughputData<T> {
+impl Debug for HumanThroughputData<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut ds = f.debug_struct("HumanThroughput");
         ds.field("val", &self.val);
@@ -40,13 +40,13 @@ impl<T: Debug + Display> Debug for HumanThroughputData<T> {
     }
 }
 
-impl<T: Display> PartialEq<HumanThroughputData<T>> for &str {
-    fn eq(&self, other: &HumanThroughputData<T>) -> bool {
+impl PartialEq<HumanThroughputData<'_>> for &str {
+    fn eq(&self, other: &HumanThroughputData<'_>) -> bool {
         utils::display_compare(self, other)
     }
 }
 
-impl<T: Display> PartialEq<&str> for HumanThroughputData<T> {
+impl PartialEq<&str> for HumanThroughputData<'_> {
     fn eq(&self, other: &&str) -> bool {
         other == self
     }
@@ -120,7 +120,7 @@ fn serialize() -> Result<(), serde_json::Error> {
     let h = 123456.human_throughput("X");
     let ser = serde_json::to_string(&h)?;
     assert_eq!(r#"{"val":123456.0,"unit":"X"}"#, &ser);
-    let h2 = serde_json::from_str::<HumanThroughputData<&str>>(&ser)?;
+    let h2 = serde_json::from_str::<HumanThroughputData>(&ser)?;
     assert_eq!(h, h2);
     Ok(())
 }

--- a/src/human_throughput.rs
+++ b/src/human_throughput.rs
@@ -1,5 +1,5 @@
 use super::{rounded, HumanThroughputData, SPACE};
-use std::{fmt, ops};
+use std::fmt::{self, Debug, Display};
 
 const SPEC: &[(f64, &str, usize)] = &[
     (24., "/d", 2),
@@ -8,9 +8,9 @@ const SPEC: &[(f64, &str, usize)] = &[
     // "/s" in code.
 ];
 
-impl<T: AsRef<str>> fmt::Display for HumanThroughputData<T> {
+impl<T: Display> Display for HumanThroughputData<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let (mut val, unit) = (self.0, self.1.as_ref());
+        let (mut val, unit) = (self.0, &self.1);
         val *= 60. * 60. * 24.;
         for &(size, scale, dec) in SPEC {
             match rounded(val, dec) {
@@ -28,26 +28,24 @@ impl<T: AsRef<str>> fmt::Display for HumanThroughputData<T> {
     }
 }
 
-impl<T: AsRef<str>> fmt::Debug for HumanThroughputData<T> {
+impl<T: Debug + Display> Debug for HumanThroughputData<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut ds = f.debug_struct("HumanThroughput");
         ds.field("val", &self.0);
-        if !self.1.as_ref().is_empty() {
-            ds.field("unit", &self.1.as_ref());
-        }
+        ds.field("unit", &self.1);
         ds.finish()?;
         write!(f, " -> ")?;
         fmt::Display::fmt(self, f)
     }
 }
 
-impl<T: AsRef<str>> PartialEq<HumanThroughputData<T>> for &str {
+impl<T: Display> PartialEq<HumanThroughputData<T>> for &str {
     fn eq(&self, other: &HumanThroughputData<T>) -> bool {
-        super::display_compare(*self, other)
+        super::display_compare(self, other)
     }
 }
 
-impl<T: AsRef<str>> PartialEq<&str> for HumanThroughputData<T> {
+impl<T: Display> PartialEq<&str> for HumanThroughputData<T> {
     fn eq(&self, other: &&str) -> bool {
         other == self
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,12 +5,28 @@ mod human_duration;
 mod human_throughput;
 mod utils;
 
-/// Human count repr generator.
-pub struct HumanCountData<T>(f64, T);
-/// Human duration repr generator.
-pub struct HumanDurationData(f64);
-/// Human throughput repr generator.
-pub struct HumanThroughputData<T>(f64, T);
+/// Human count data, ready to generate Debug and Display representations.
+#[derive(PartialEq, PartialOrd)] // Debug and Display impls in the specific module.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct HumanCountData<T> {
+    val: f64,
+    unit: T,
+}
+
+/// Human duration data, ready to generate Debug and Display representations.
+#[derive(PartialEq, PartialOrd)] // Debug and Display impls in the specific module.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct HumanDurationData {
+    val: f64,
+}
+
+/// Human throughput data, ready to generate Debug and Display representations.
+#[derive(PartialEq, PartialOrd)] // Debug and Display impls in the specific module.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct HumanThroughputData<T> {
+    val: f64,
+    unit: T,
+}
 
 const BYTES: &str = "B";
 
@@ -101,17 +117,17 @@ macro_rules! impl_trait {
     {$($t:ty),+} => {$(
         impl HumanCount for $t {
             fn human_count<T>(self, unit: T) -> HumanCountData<T> {
-                HumanCountData(self as f64, unit)
+                HumanCountData{val: self as f64, unit}
             }
         }
         impl HumanDuration for $t {
             fn human_duration(self) -> HumanDurationData {
-                HumanDurationData(self as f64)
+                HumanDurationData{val: self as f64}
             }
         }
         impl HumanThroughput for $t {
             fn human_throughput<T>(self, unit: T) -> HumanThroughputData<T> {
-                HumanThroughputData(self as f64, unit)
+                HumanThroughputData{val: self as f64, unit}
             }
         }
     )+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ mod human_duration;
 mod human_throughput;
 mod utils;
 
-/// Human count data, ready to generate Debug and Display representations.
+/// Human Count data, ready to generate Debug and Display representations.
 #[derive(PartialEq, PartialOrd)] // Debug and Display impls in the specific module.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HumanCountData<T> {
@@ -16,14 +16,14 @@ pub struct HumanCountData<T> {
     unit: T,
 }
 
-/// Human duration data, ready to generate Debug and Display representations.
+/// Human Duration data, ready to generate Debug and Display representations.
 #[derive(PartialEq, PartialOrd)] // Debug and Display impls in the specific module.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HumanDurationData {
     val: f64,
 }
 
-/// Human throughput data, ready to generate Debug and Display representations.
+/// Human Throughput data, ready to generate Debug and Display representations.
 #[derive(PartialEq, PartialOrd)] // Debug and Display impls in the specific module.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HumanThroughputData<T> {
@@ -33,7 +33,7 @@ pub struct HumanThroughputData<T> {
 
 const BYTES: &str = "B";
 
-/// Human Count functionality provider, supporting all Rust primitive number types.
+/// Human Count trait, supporting all Rust primitive number types.
 pub trait HumanCount: sealed::Sealed + Sized {
     /// Generate beautiful human-readable counts supporting automatic prefixes and custom units.
     #[cfg_attr(
@@ -79,7 +79,7 @@ assert_eq!("4.2MB", 4221432u32.human_count_bytes());
     }
 }
 
-/// Human Duration functionality provider, supporting all Rust primitive number types and Duration.
+/// Human Duration trait, supporting all Rust primitive number types and Duration.
 pub trait HumanDuration: sealed::Sealed + Sized {
     /// Generate beautiful human-readable durations supporting automatic prefixes.
     #[cfg_attr(
@@ -105,7 +105,7 @@ assert_eq!("160ms", d.human_duration());
     fn human_duration(self) -> HumanDurationData;
 }
 
-/// Human Throughput functionality provider, supporting all Rust primitive number types.
+/// Human Throughput trait, supporting all Rust primitive number types.
 pub trait HumanThroughput: sealed::Sealed + Sized {
     /// Generate beautiful human-readable throughputs supporting automatic prefixes and custom units.
     #[cfg_attr(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,7 @@
-#![doc = include_str!("../README.md")]
+#![cfg_attr(
+    not(any(feature = "1024", feature = "iec", feature = "space")), 
+    doc = include_str!("../README.md")
+)]
 
 mod human_count;
 mod human_duration;
@@ -33,29 +36,44 @@ const BYTES: &str = "B";
 /// Human representation count trait, supporting all Rust primitive number types.
 pub trait HumanCount: sealed::Sealed + Sized {
     /// Generate beautiful human-readable counts supporting automatic prefixes and custom units.
-    ///
-    /// ```
-    /// use human_repr::HumanCount;
-    /// assert_eq!("4.2Mcoins", 4221432u32.human_count("coins"));
-    /// ```
+    #[cfg_attr(
+        not(any(feature = "1024", feature = "iec", feature = "space")),
+        doc = r#"
+
+```
+use human_repr::HumanCount;
+assert_eq!("4.2Mcoins", 4221432u32.human_count("coins"));
+```
+"#
+    )]
     fn human_count<T>(self, unit: T) -> HumanCountData<T>;
 
     /// Generate beautiful human-readable counts supporting automatic prefixes.
-    ///
-    /// ```
-    /// use human_repr::HumanCount;
-    /// assert_eq!("4.2M", 4221432u32.human_count_bare());
-    /// ```
+    #[cfg_attr(
+        not(any(feature = "1024", feature = "iec", feature = "space")),
+        doc = r#"
+
+```
+use human_repr::HumanCount;
+assert_eq!("4.2M", 4221432u32.human_count_bare());
+```
+"#
+    )]
     fn human_count_bare(self) -> HumanCountData<&'static str> {
         self.human_count("")
     }
 
     /// Generate beautiful human-readable counts supporting automatic prefixes and Bytes `B` as the unit.
-    ///
-    /// ```
-    /// use human_repr::HumanCount;
-    /// assert_eq!("4.2MB", 4221432u32.human_count_bytes());
-    /// ```
+    #[cfg_attr(
+        not(any(feature = "1024", feature = "iec", feature = "space")),
+        doc = r#"
+
+```
+use human_repr::HumanCount;
+assert_eq!("4.2MB", 4221432u32.human_count_bytes());
+```
+"#
+    )]
     fn human_count_bytes(self) -> HumanCountData<&'static str> {
         self.human_count(BYTES)
     }
@@ -64,50 +82,70 @@ pub trait HumanCount: sealed::Sealed + Sized {
 /// Human representation duration trait, supporting all Rust primitive number types and Duration.
 pub trait HumanDuration: sealed::Sealed + Sized {
     /// Generate beautiful human-readable durations supporting automatic prefixes.
-    ///
-    /// Use either with primitives:
-    /// ```
-    /// use human_repr::HumanDuration;
-    /// assert_eq!("160ms", 0.1599999.human_duration());
-    /// ```
-    ///
-    /// Or with [`Duration`](`std::time::Duration`)s:
-    /// ```
-    /// use human_repr::HumanDuration;
-    /// use std::time::Duration;
-    ///
-    /// let d = Duration::from_secs_f64(0.1599999);
-    /// assert_eq!("160ms", d.human_duration());
-    /// ```
+    #[cfg_attr(
+        not(any(feature = "1024", feature = "iec", feature = "space")),
+        doc = r#"
+
+Use either with primitives:
+```
+use human_repr::HumanDuration;
+assert_eq!("160ms", 0.1599999.human_duration());
+```
+
+Or with [`Duration`](`std::time::Duration`)s:
+```
+use human_repr::HumanDuration;
+use std::time::Duration;
+
+let d = Duration::from_secs_f64(0.1599999);
+assert_eq!("160ms", d.human_duration());
+```
+"#
+    )]
     fn human_duration(self) -> HumanDurationData;
 }
 
 /// Human representation throughput trait, supporting all Rust primitive number types.
 pub trait HumanThroughput: sealed::Sealed + Sized {
     /// Generate beautiful human-readable throughputs supporting automatic prefixes and custom units.
-    ///
-    /// ```
-    /// use human_repr::HumanThroughput;
-    /// assert_eq!("1.2k°C/s", 1234.5.human_throughput("°C"));
-    /// ```
+    #[cfg_attr(
+        not(any(feature = "1024", feature = "iec", feature = "space")),
+        doc = r#"
+
+```
+use human_repr::HumanThroughput;
+assert_eq!("1.2k°C/s", 1234.5.human_throughput("°C"));
+```
+"#
+    )]
     fn human_throughput<T>(self, unit: T) -> HumanThroughputData<T>;
 
     /// Generate beautiful human-readable throughputs supporting automatic prefixes.
-    ///
-    /// ```
-    /// use human_repr::HumanThroughput;
-    /// assert_eq!("1.2k/s", 1234.5.human_throughput_bare());
-    /// ```
+    #[cfg_attr(
+        not(any(feature = "1024", feature = "iec", feature = "space")),
+        doc = r#"
+
+```
+use human_repr::HumanThroughput;
+assert_eq!("1.2k/s", 1234.5.human_throughput_bare());
+```
+"#
+    )]
     fn human_throughput_bare(self) -> HumanThroughputData<&'static str> {
         self.human_throughput("")
     }
 
     /// Generate beautiful human-readable throughputs supporting automatic prefixes and Bytes `B` as the unit.
-    ///
-    /// ```
-    /// use human_repr::HumanThroughput;
-    /// assert_eq!("1.2kB/s", 1234.5.human_throughput_bytes());
-    /// ```
+    #[cfg_attr(
+        not(any(feature = "1024", feature = "iec", feature = "space")),
+        doc = r#"
+
+```
+use human_repr::HumanThroughput;
+assert_eq!("1.2kB/s", 1234.5.human_throughput_bytes());
+```
+"#
+    )]
     fn human_throughput_bytes(self) -> HumanThroughputData<&'static str> {
         self.human_throughput(BYTES)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ pub struct HumanThroughputData<T> {
 
 const BYTES: &str = "B";
 
-/// Human representation count trait, supporting all Rust primitive number types.
+/// Human Count functionality provider, supporting all Rust primitive number types.
 pub trait HumanCount: sealed::Sealed + Sized {
     /// Generate beautiful human-readable counts supporting automatic prefixes and custom units.
     #[cfg_attr(
@@ -79,7 +79,7 @@ assert_eq!("4.2MB", 4221432u32.human_count_bytes());
     }
 }
 
-/// Human representation duration trait, supporting all Rust primitive number types and Duration.
+/// Human Duration functionality provider, supporting all Rust primitive number types and Duration.
 pub trait HumanDuration: sealed::Sealed + Sized {
     /// Generate beautiful human-readable durations supporting automatic prefixes.
     #[cfg_attr(
@@ -105,7 +105,7 @@ assert_eq!("160ms", d.human_duration());
     fn human_duration(self) -> HumanDurationData;
 }
 
-/// Human representation throughput trait, supporting all Rust primitive number types.
+/// Human Throughput functionality provider, supporting all Rust primitive number types.
 pub trait HumanThroughput: sealed::Sealed + Sized {
     /// Generate beautiful human-readable throughputs supporting automatic prefixes and custom units.
     #[cfg_attr(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,11 @@ mod human_throughput;
 use std::fmt;
 use std::time::Duration;
 
+/// Human count repr generator.
 pub struct HumanCountData<T>(f64, T);
+/// Human duration repr generator.
 pub struct HumanDurationData(f64);
+/// Human throughput repr generator.
 pub struct HumanThroughputData<T>(f64, T);
 
 const BYTES: &str = "B";

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,35 @@
+use std::fmt;
+
+pub const SPACE: &str = {
+    match cfg!(feature = "space") {
+        true => " ",
+        false => "",
+    }
+};
+
+#[inline]
+pub fn rounded(val: f64, dec: usize) -> f64 {
+    match dec {
+        0 => val.round(),
+        1 => (val * 10.).round() / 10.,
+        2 => (val * 100.).round() / 100.,
+        _ => unreachable!(),
+    }
+}
+
+pub struct DisplayCompare<'a, I>(&'a mut I);
+
+impl<I: Iterator<Item = u8>> fmt::Write for DisplayCompare<'_, I> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        match s.bytes().zip(self.0.by_ref()).all(|(x, y)| x == y) {
+            true => Ok(()),
+            false => Err(fmt::Error),
+        }
+    }
+}
+
+pub fn display_compare(str: &str, display: &impl fmt::Display) -> bool {
+    let mut it = str.bytes();
+    use fmt::Write;
+    write!(DisplayCompare(it.by_ref()), "{display}").map_or(false, |_| it.len() == 0)
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -21,15 +21,19 @@ pub struct DisplayCompare<'a, I>(&'a mut I);
 
 impl<I: Iterator<Item = u8>> fmt::Write for DisplayCompare<'_, I> {
     fn write_str(&mut self, s: &str) -> fmt::Result {
-        match s.bytes().zip(self.0.by_ref()).all(|(x, y)| x == y) {
+        match s
+            .bytes()
+            .map(|c| (c, self.0.next()))
+            .all(|(x, y)| x == y.unwrap_or_default())
+        {
             true => Ok(()),
             false => Err(fmt::Error),
         }
     }
 }
 
-pub fn display_compare(str: &str, display: &impl fmt::Display) -> bool {
-    let mut it = str.bytes();
+pub fn display_compare(expected: &str, human: &impl fmt::Display) -> bool {
+    let mut it = expected.bytes();
     use fmt::Write;
-    write!(DisplayCompare(it.by_ref()), "{display}").map_or(false, |_| it.len() == 0)
+    write!(DisplayCompare(it.by_ref()), "{human}").map_or(false, |_| it.len() == 0)
 }

--- a/tests/mixed_serialize.rs
+++ b/tests/mixed_serialize.rs
@@ -1,0 +1,32 @@
+#[cfg(feature = "serde")]
+mod tests {
+    use human_repr::{
+        HumanCount, HumanCountData, HumanDuration, HumanDurationData, HumanThroughput,
+        HumanThroughputData,
+    };
+    use serde::{Deserialize, Serialize};
+
+    #[test]
+    fn mixed_serialize() -> Result<(), serde_json::Error> {
+        #[derive(Debug, PartialEq, Serialize, Deserialize)]
+        #[serde(bound(deserialize = "'de: 'a"))]
+        enum Data<'a> {
+            Count(HumanCountData<&'a str>),
+            Duration(HumanDurationData),
+            Throughput(HumanThroughputData<&'a str>),
+        }
+        let list = [
+            Data::Count(123456.human_count("C")),
+            Data::Duration(123456.human_duration()),
+            Data::Throughput(123456.human_throughput("T")),
+        ];
+        let ser = serde_json::to_string(&list)?;
+        assert_eq!(
+            r#"[{"Count":{"val":123456.0,"unit":"C"}},{"Duration":{"val":123456.0}},{"Throughput":{"val":123456.0,"unit":"T"}}]"#,
+            &ser
+        );
+        let list2 = serde_json::from_str::<Vec<Data>>(&ser)?;
+        assert_eq!(list, list2.as_slice());
+        Ok(())
+    }
+}

--- a/tests/mixed_serialize.rs
+++ b/tests/mixed_serialize.rs
@@ -11,9 +11,9 @@ mod tests {
         #[derive(Debug, PartialEq, Serialize, Deserialize)]
         #[serde(bound(deserialize = "'de: 'a"))]
         enum Data<'a> {
-            Count(HumanCountData<&'a str>),
+            Count(HumanCountData<'a>),
             Duration(HumanDurationData),
-            Throughput(HumanThroughputData<&'a str>),
+            Throughput(HumanThroughputData<'a>),
         }
         let list = [
             Data::Count(123456.human_count("C")),


### PR DESCRIPTION
This version mainly:
- includes an optional feature for `serde`;
- uses [`Cow`](`std::borrow::Cow`) instead of generics for units (possibly more optimized binary);
- changes minute's symbol in throughputs from `m` to `min` (it seems this is the actual SI accepted symbol).

As well as polishing everything up.

Fixes #3.